### PR TITLE
fixed nodemon restart loop by setting multiple ignore flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Chatbot for twitch.tv/metalandcoffee_",
 	"main": "app.js",
 	"scripts": {
-		"start": "nodemon app.js --ignore 'components/*.json,components/tmp/*.json'",
+		"start": "nodemon app.js --ignore 'components/*.json' --ignore 'components/tmp/*.json'",
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
 	"type": "module",


### PR DESCRIPTION
Hey, I took a look at the nodemon problem, and from what I can tell from the partially muted stream, you want to ignore the timers.json, right? Setting the --ignore flag twice did make it start up just fine for me :) Hope this helps!